### PR TITLE
Allow doctrine/persistence:^3.0; drop EOL versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: ['7.3', '7.4', '8.0']
+                php: ['8.1', '8.2', '8.3']
                 dependencies: ['lowest', 'highest']
         name: PHP ${{ matrix.php }} tests on deps=${{ matrix.dependencies }}
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ext-mongodb": "*",
         "ramsey/uuid": "~3.0|^4",
         "doctrine/mongodb-odm": "^2.0",
-        "doctrine/persistence": "^1.3.3|^2.0"
+        "doctrine/persistence": "^1.3.3|^2.0|^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5"

--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,11 @@
         }
     ],
     "require": {
-        "php" : "^7.3|^8.0",
+        "php" : "^8.0",
         "ext-mongodb": "*",
         "ramsey/uuid": "~3.0|^4",
         "doctrine/mongodb-odm": "^2.0",
-        "doctrine/persistence": "^1.3.3|^2.0|^3.0"
+        "doctrine/persistence": "^2.0|^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5"


### PR DESCRIPTION
- Allow the current version of doctrine/persistence
- Drop doctrine/persistence:^1
- Drop EOL PHP versions: 7.3, 7.4, 8.0
- Add PHP 8.1, 8.2, 8.3 to CI
